### PR TITLE
Fixed horizontal scroll in admin user grid

### DIFF
--- a/less/admin/UserListPage.less
+++ b/less/admin/UserListPage.less
@@ -1,7 +1,5 @@
 .UserListPage-grid {
   grid-gap: 1px 0;
-  width: -webkit-fit-content;
-  width: fit-content;
 
   &-header,
   // @todo rowItem


### PR DESCRIPTION
Issue
--------
In the Users admin section, the user grid does not horizontally scroll to access content off screen. This makes mobile user administration difficult.

Example:
![image](https://github.com/afrux/asirem/assets/5646444/62d884e9-88eb-4ad8-ad75-6020679f9c4a)

Fix
--------
Removed width CSS from user grid to allow horizontal scrollbar to render.

![image](https://github.com/afrux/asirem/assets/5646444/cb2fc5df-eda5-443b-8272-3891d209d39e)
